### PR TITLE
Remove development deploy from travis conf

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ install:
   - npm install
 
 script:
-  - npm run deploy:dev
   - npm run deploy:prod
 
 after_success:


### PR DESCRIPTION
Development deploy uses webpack-dashboard which is not happy without itself.