### PR TITLE
Feature/print view for tos

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "passport": "^0.3.2",
     "passport-helsinki": "City-of-Helsinki/passport-helsinki",
     "promise-polyfill": "^6.0.2",
+    "prop-types": "^15.6.0",
     "raven-js": "^3.17.0",
     "react": "^15.4.1",
     "react-addons-css-transition-group": "^15.4.1",

--- a/src/components/Tos/Header/ActionButtons.js
+++ b/src/components/Tos/Header/ActionButtons.js
@@ -1,4 +1,6 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Link } from 'react-router';
 
 import IsAllowed from 'components/IsAllowed/IsAllowed';
 import ActionButton from './ActionButton';
@@ -110,21 +112,30 @@ const ActionButtons = ({
 
   return (
     <div>
-      { status === DRAFT && editable }
-      { status === SENT_FOR_REVIEW && reviewable }
-      { status === WAITING_FOR_APPROVAL && approvable }
-      { status === APPROVED && draftable }
-      { status !== APPROVED &&
-      <div className='validation-button'>
-        <ActionButton
-          className='btn-sm pull-right'
-          style={{ marginRight: '15px' }}
-          type='success'
-          action={() => setValidationVisibility(true)}
-          label={'Esitarkasta'}
-          icon={'fa-check-circle-o'}
-        />
-      </div>}
+      {status === DRAFT && editable}
+      {status === SENT_FOR_REVIEW && reviewable}
+      {status === WAITING_FOR_APPROVAL && approvable}
+      {status === APPROVED && draftable}
+      {status !== APPROVED && (
+        <div className='validation-button'>
+          <ActionButton
+            className='btn-sm pull-right'
+            style={{ marginRight: '15px' }}
+            type='success'
+            action={() => setValidationVisibility(true)}
+            label={'Esitarkasta'}
+            icon={'fa-check-circle-o'}
+          />
+        </div>
+      )}
+      <span>
+        <Link
+          className='btn btn-sm btn-primary'
+          to={`/view-tos/${tosId}/print`}
+        >
+          Tulosta
+        </Link>
+      </span>
     </div>
   );
 };

--- a/src/components/Tos/Print/MetaDataTable.js
+++ b/src/components/Tos/Print/MetaDataTable.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const Table = ({ rows }) => (
+  <table>
+    <caption>Metatiedot</caption>
+    <tbody>
+      {rows.map(row => {
+        const [title, ...cells] = row;
+        return (
+          <tr key={title}>
+            <th scope='row'>{title}</th>
+            {cells.map(value => <td key={`${title}.${value}`}>{value}</td>)}
+          </tr>
+        );
+      })}
+    </tbody>
+  </table>
+);
+
+Table.propTypes = {
+  rows: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.string))
+};
+
+export default Table;

--- a/src/components/Tos/Print/PrintAction.js
+++ b/src/components/Tos/Print/PrintAction.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import MetaDataTable from './MetaDataTable';
+import PrintRecord from './PrintRecord';
+
+const PrintAction = ({
+  action,
+  phaseName,
+  getAttributeName,
+  sortAttributeKeys
+}) => (
+  <section>
+    <header>
+      <div className='breadscrumbs'>{phaseName}</div>
+      <h3>{action.name}</h3>
+    </header>
+    <main>
+      <MetaDataTable
+        rows={sortAttributeKeys(Object.keys(action.attributes)).map(key => [
+          getAttributeName(key),
+          action.attributes[key]
+        ])}
+      />
+      {action.records
+        ? action.records.map(record => (
+          <PrintRecord
+              key={record.id}
+              record={record}
+              breadscrumbs={[phaseName, action.name].join(' » ')}
+              getAttributeName={getAttributeName}
+              sortAttributeKeys={sortAttributeKeys}
+            />
+          ))
+        : null}
+    </main>
+  </section>
+);
+
+PrintAction.propTypes = {
+  action: PropTypes.object.isRequired,
+  getAttributeName: PropTypes.func.isRequired,
+  phaseName: PropTypes.string,
+  sortAttributeKeys: PropTypes.func.isRequired
+};
+
+export default PrintAction;

--- a/src/components/Tos/Print/PrintAction.js
+++ b/src/components/Tos/Print/PrintAction.js
@@ -15,25 +15,23 @@ const PrintAction = ({
       <div className='breadscrumbs'>{phaseName}</div>
       <h3>{action.name}</h3>
     </header>
-    <main>
-      <MetaDataTable
-        rows={sortAttributeKeys(Object.keys(action.attributes)).map(key => [
-          getAttributeName(key),
-          action.attributes[key]
-        ])}
-      />
-      {action.records
-        ? action.records.map(record => (
-          <PrintRecord
-              key={record.id}
-              record={record}
-              breadscrumbs={[phaseName, action.name].join(' » ')}
-              getAttributeName={getAttributeName}
-              sortAttributeKeys={sortAttributeKeys}
-            />
-          ))
-        : null}
-    </main>
+    <MetaDataTable
+      rows={sortAttributeKeys(Object.keys(action.attributes)).map(key => [
+        getAttributeName(key),
+        action.attributes[key]
+      ])}
+    />
+    {action.records
+      ? action.records.map(record => (
+        <PrintRecord
+            key={record.id}
+            record={record}
+            breadscrumbs={[phaseName, action.name].join(' » ')}
+            getAttributeName={getAttributeName}
+            sortAttributeKeys={sortAttributeKeys}
+          />
+        ))
+      : null}
   </section>
 );
 

--- a/src/components/Tos/Print/PrintPhase.js
+++ b/src/components/Tos/Print/PrintPhase.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import MetaDataTable from './MetaDataTable';
+import PrintAction from './PrintAction';
+
+const PrintPhase = ({ phase, getAttributeName, sortAttributeKeys }) => {
+  const metaData = sortAttributeKeys(Object.keys(phase.attributes)).map(key => [
+    getAttributeName(key),
+    phase.attributes[key]
+  ]);
+  return (
+    <section>
+      <header>
+        <h2>{phase.name}</h2>
+      </header>
+      <main>
+        <MetaDataTable rows={metaData} />
+        {phase.actions.map(action => (
+          <PrintAction
+            key={action.id}
+            action={action}
+            phaseName={phase.name}
+            getAttributeName={getAttributeName}
+            sortAttributeKeys={sortAttributeKeys}
+          />
+        ))}
+      </main>
+    </section>
+  );
+};
+
+const PhaseShape = PropTypes.shape({
+  actions: PropTypes.arrayOf(PropTypes.object),
+  attributes: PropTypes.object,
+  id: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired
+});
+
+PrintPhase.propTypes = {
+  getAttributeName: PropTypes.func.isRequired,
+  phase: PhaseShape,
+  sortAttributeKeys: PropTypes.func.isRequired
+};
+
+export default PrintPhase;

--- a/src/components/Tos/Print/PrintPhase.js
+++ b/src/components/Tos/Print/PrintPhase.js
@@ -14,18 +14,16 @@ const PrintPhase = ({ phase, getAttributeName, sortAttributeKeys }) => {
       <header>
         <h2>{phase.name}</h2>
       </header>
-      <main>
-        <MetaDataTable rows={metaData} />
-        {phase.actions.map(action => (
-          <PrintAction
-            key={action.id}
-            action={action}
-            phaseName={phase.name}
-            getAttributeName={getAttributeName}
-            sortAttributeKeys={sortAttributeKeys}
-          />
-        ))}
-      </main>
+      <MetaDataTable rows={metaData} />
+      {phase.actions.map(action => (
+        <PrintAction
+          key={action.id}
+          action={action}
+          phaseName={phase.name}
+          getAttributeName={getAttributeName}
+          sortAttributeKeys={sortAttributeKeys}
+        />
+      ))}
     </section>
   );
 };

--- a/src/components/Tos/Print/PrintRecord.js
+++ b/src/components/Tos/Print/PrintRecord.js
@@ -15,14 +15,12 @@ const PrintRecord = ({
       <div className='breadscrumbs'>{breadscrumbs}</div>
       <h4>{upperFirst(record.name)}</h4>
     </header>
-    <main>
-      <MetaDataTable
-        rows={sortAttributeKeys(Object.keys(record.attributes)).map(key => [
-          getAttributeName(key),
-          record.attributes[key]
-        ])}
-      />
-    </main>
+    <MetaDataTable
+      rows={sortAttributeKeys(Object.keys(record.attributes)).map(key => [
+        getAttributeName(key),
+        record.attributes[key]
+      ])}
+    />
   </section>
 );
 

--- a/src/components/Tos/Print/PrintRecord.js
+++ b/src/components/Tos/Print/PrintRecord.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import upperFirst from 'lodash/upperFirst';
+
+import MetaDataTable from './MetaDataTable';
+
+const PrintRecord = ({
+  record,
+  breadscrumbs,
+  getAttributeName,
+  sortAttributeKeys
+}) => (
+  <section>
+    <header>
+      <div className='breadscrumbs'>{breadscrumbs}</div>
+      <h4>{upperFirst(record.name)}</h4>
+    </header>
+    <main>
+      <MetaDataTable
+        rows={sortAttributeKeys(Object.keys(record.attributes)).map(key => [
+          getAttributeName(key),
+          record.attributes[key]
+        ])}
+      />
+    </main>
+  </section>
+);
+
+PrintRecord.propTypes = {
+  breadscrumbs: PropTypes.string,
+  getAttributeName: PropTypes.func.isRequired,
+  record: PropTypes.object.isRequired,
+  sortAttributeKeys: PropTypes.func.isRequired
+};
+
+export default PrintRecord;

--- a/src/components/Tos/Print/PrintView.js
+++ b/src/components/Tos/Print/PrintView.js
@@ -72,28 +72,26 @@ class PrintView extends React.Component {
             {TOS.function_id} {TOS.name}
           </h1>
         </header>
-        <main>
-          <MetaDataTable
-            rows={[
-              ['Versionumero', TOS.version.toString()],
-              ['Tila', getStatusLabel(TOS.status)],
-              ['Muokkausajankohta', formatDateTime(TOS.modified_at)],
-              ['Muokkaaja', TOS.modified_by],
-              ...sortAttributeKeys(Object.keys(TOS.attributes)).map(key => [
-                getAttributeName(key),
-                TOS.attributes[key]
-              ])
-            ]}
+        <MetaDataTable
+          rows={[
+            ['Versionumero', TOS.version.toString()],
+            ['Tila', getStatusLabel(TOS.status)],
+            ['Muokkausajankohta', formatDateTime(TOS.modified_at)],
+            ['Muokkaaja', TOS.modified_by],
+            ...sortAttributeKeys(Object.keys(TOS.attributes)).map(key => [
+              getAttributeName(key),
+              TOS.attributes[key]
+            ])
+          ]}
+        />
+        {Object.keys(TOS.phases).map(key => (
+          <PrintPhase
+            key={TOS.phases[key].id}
+            phase={TOS.phases[key]}
+            getAttributeName={getAttributeName}
+            sortAttributeKeys={sortAttributeKeys}
           />
-          {Object.keys(TOS.phases).map(key => (
-            <PrintPhase
-              key={TOS.phases[key].id}
-              phase={TOS.phases[key]}
-              getAttributeName={getAttributeName}
-              sortAttributeKeys={sortAttributeKeys}
-            />
-          ))}
-        </main>
+        ))}
       </article>
     );
   }

--- a/src/components/Tos/Print/PrintView.js
+++ b/src/components/Tos/Print/PrintView.js
@@ -1,0 +1,147 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { bindActionCreators, compose } from 'redux';
+import { withRouter, Link } from 'react-router';
+import get from 'lodash/get';
+
+import { fetchTOS } from 'components/Tos/reducer';
+import { setValidationVisibility } from 'components/Tos/ValidationBar/reducer';
+import { getStatusLabel, formatDateTime } from 'utils/helpers';
+
+import MetaDataTable from './MetaDataTable';
+import PrintPhase from './PrintPhase';
+
+import './PrintView.scss';
+
+class PrintView extends React.Component {
+  static BODY_CLASS = 'helerm-tos-print-view';
+
+  componentDidMount () {
+    const { fetchTOS, TOS, hideNavigation, params: { id } } = this.props;
+    this.addBodyClass();
+    hideNavigation();
+
+    const tosAvailable = TOS.id === id;
+    if (!tosAvailable) {
+      fetchTOS(id);
+    }
+  }
+
+  componentWillUnmount () {
+    this.removeBodyClass();
+  }
+
+  addBodyClass () {
+    if (document.body) {
+      document.body.className = document.body.className + PrintView.BODY_CLASS;
+    }
+  }
+
+  removeBodyClass () {
+    if (document.body) {
+      document.body.className = document.body.className.replace(
+        PrintView.BODY_CLASS,
+        ''
+      );
+    }
+  }
+
+  render () {
+    const { TOS, getAttributeName, sortAttributeKeys, location } = this.props;
+    if (!TOS.id) return null;
+    return (
+      <article>
+        <header>
+          <div className='no-print btn-group'>
+            <Link
+              className='btn btn-primary'
+              to={location.pathname.replace('/print', '')}
+            >
+              Takaisin <i className='fa fa-close' />
+            </Link>
+            <button
+              type='button'
+              className='btn btn-success'
+              onClick={window.print}
+            >
+              Tulosta <i className='fa fa-print' />
+            </button>
+          </div>
+          <h1>
+            {TOS.function_id} {TOS.name}
+          </h1>
+        </header>
+        <main>
+          <MetaDataTable
+            rows={[
+              ['Versionumero', TOS.version.toString()],
+              ['Tila', getStatusLabel(TOS.status)],
+              ['Muokkausajankohta', formatDateTime(TOS.modified_at)],
+              ['Muokkaaja', TOS.modified_by],
+              ...sortAttributeKeys(Object.keys(TOS.attributes)).map(key => [
+                getAttributeName(key),
+                TOS.attributes[key]
+              ])
+            ]}
+          />
+          {Object.keys(TOS.phases).map(key => (
+            <PrintPhase
+              key={TOS.phases[key].id}
+              phase={TOS.phases[key]}
+              getAttributeName={getAttributeName}
+              sortAttributeKeys={sortAttributeKeys}
+            />
+          ))}
+        </main>
+      </article>
+    );
+  }
+}
+
+PrintView.propTypes = {
+  TOS: PropTypes.object,
+  fetchTOS: PropTypes.func.isRequired,
+  getAttributeName: PropTypes.func.isRequired,
+  hideNavigation: PropTypes.func.isRequired,
+  location: PropTypes.object.isRequired,
+  params: PropTypes.object,
+  sortAttributeKeys: PropTypes.func.isRequired
+};
+
+const denormalizeTOS = tos => ({
+  ...tos,
+  phases: Object.values(tos.phases)
+    .sort((a, b) => a.index - b.inded)
+    .map(phase => ({
+      ...phase,
+      actions: phase.actions.map(actionKey => {
+        const action = tos.actions[actionKey];
+        return {
+          ...action,
+          records: action.records.map(recordKey => tos.records[recordKey])
+        };
+      })
+    }))
+});
+
+const mapStateToProps = state => ({
+  TOS: denormalizeTOS(state.selectedTOS),
+  getAttributeName: key => get(state.ui.attributeTypes, `[${key}].name`, key),
+  sortAttributeKeys: keys =>
+    keys.sort(key => get(state.ui.attributeTypes, `[${key}].index`, Infinity))
+});
+
+const mapDispatchToProps = dispatch =>
+  bindActionCreators(
+    {
+      fetchTOS,
+      hideNavigation: () => setValidationVisibility(false)
+    },
+    dispatch
+  );
+
+export default compose(
+  withRouter,
+  connect(mapStateToProps, mapDispatchToProps)
+)(PrintView);

--- a/src/components/Tos/Print/PrintView.js
+++ b/src/components/Tos/Print/PrintView.js
@@ -125,9 +125,9 @@ const denormalizeTOS = tos => ({
 
 const mapStateToProps = state => ({
   TOS: denormalizeTOS(state.selectedTOS),
-  getAttributeName: key => get(state.ui.attributeTypes, `[${key}].name`, key),
+  getAttributeName: key => get(state.ui.attributeTypes, [key, 'name'], key),
   sortAttributeKeys: keys =>
-    keys.sort(key => get(state.ui.attributeTypes, `[${key}].index`, Infinity))
+    keys.sort(key => get(state.ui.attributeTypes, [key, 'index'], Infinity))
 });
 
 const mapDispatchToProps = dispatch =>

--- a/src/components/Tos/Print/PrintView.scss
+++ b/src/components/Tos/Print/PrintView.scss
@@ -1,0 +1,36 @@
+body.helerm-tos-print-view {
+  .navigation-menu {
+    display: none;
+  }
+
+  table td,
+  table th {
+    padding: 0.5em;
+    border: 1px solid #ddd;
+  }
+
+  section {
+    padding: 1em;
+    margin: 1em auto;
+  }
+
+  section section {
+    border: 1px solid #999;
+  }
+
+  div.breadscrumbs {
+    margin-bottom: 0;
+
+    & + h3,
+    & + h4 {
+      margin-top: 0;
+    }
+  }
+
+  @media print {
+    .no-print,
+    .helerm-banner {
+      display: none;
+    }
+  }
+}

--- a/src/index.html
+++ b/src/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="fi">
 <!--
   git-version: <%= htmlWebpackPlugin.options.VERSION %>
   git commit hash: <%= htmlWebpackPlugin.options.HASH %>

--- a/src/routes.js
+++ b/src/routes.js
@@ -4,6 +4,7 @@ import CoreLayout from './layouts/CoreLayout/CoreLayout';
 import InfoLayout from './layouts/InfoLayout/InfoLayout';
 import ViewTOSContainer from './components/Tos/ViewTos/ViewTosContainer';
 import ViewInfo from './components/Info/ViewInfo';
+import PrintTOS from 'components/Tos/Print/PrintView';
 import NotFound from './components/NotFound/NotFound';
 
 export default () => (
@@ -11,7 +12,10 @@ export default () => (
     <Route path='/'>
       <IndexRoute component={CoreLayout} />
       <Route path='view-tos/' component={CoreLayout}>
-        <Route path=':id' component={ViewTOSContainer} />
+        <Route path=':id'>
+          <IndexRoute component={ViewTOSContainer} />
+          <Route path='print' component={PrintTOS} />
+        </Route>
       </Route>
       <Route path='info' component={InfoLayout}>
         <IndexRoute component={ViewInfo} />


### PR DESCRIPTION
Add `/view-tos/:id/print` route that displays all metadata, phases, actions and sections that TOS has.

Example PDF print of the view: 
[Otsikkotaso-4.pdf](https://github.com/City-of-Helsinki/helerm-ui/files/1569024/Otsikkotasp-4.pdf)



Solves #110 