### PR TITLE
Use FEEDBACK_URL instead of hardcoded mailto-link

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,8 @@ APP_URL=http://localhost:3000
 CLIENT_AUDIENCE=
 CLIENT_ID=
 CLIENT_SECRET=
-FEEDBACK_EMAIL=
+# url or mailto:-link
+FEEDBACK_URL=
 JWT_TOKEN=
 RESULTS_PER_PAGE=2000
 # if SERVER_HOST is used it should match the host in APP_URL

--- a/.eslintrc
+++ b/.eslintrc
@@ -23,7 +23,7 @@
     "GIT_COMMIT_HASH"       : false,
     "SENTRY_REPORT_DIALOG"  : false,
     "SENTRY_DSN"            : false,
-    "FEEDBACK_EMAIL"          : false,
+    "FEEDBACK_URL"          : false,
     "SITE_TITLE"            : false,
     "__DEV__"               : false,
     "__TEST__"              : false,

--- a/config/index.js
+++ b/config/index.js
@@ -73,7 +73,7 @@ config.globals = {
   SENTRY_REPORT_DIALOG: process.env.SENTRY_REPORT_DIALOG,
   RESULTS_PER_PAGE: JSON.stringify(process.env.RESULTS_PER_PAGE),
   STORAGE_PREFIX: JSON.stringify(process.env.STORAGE_PREFIX || 'HELERM'),
-  FEEDBACK_EMAIL: JSON.stringify(process.env.FEEDBACK_EMAIL),
+  FEEDBACK_URL: JSON.stringify(process.env.FEEDBACK_URL),
   SITE_TITLE: JSON.stringify(process.env.SITE_TITLE || '')
 };
 

--- a/src/components/Banner/index.js
+++ b/src/components/Banner/index.js
@@ -8,7 +8,9 @@ export default () => (
     <Banner.Element background='blue'>
       <a
         style={{ color: '#fff' }}
-        href={`mailto:${FEEDBACK_EMAIL}?subject=Tiedonohjaus-palaute`}
+        href={`${FEEDBACK_URL}`}
+        target='_blank'
+        rel='noopener norefer'
       >
         Anna palautetta
       </a>


### PR DESCRIPTION
Fixes #215.
@vikoivun needs to define `FEEDBACK_URL` to demo. 

```
FEEDBACK_URL='mailto:demo@example.com' or
FEEDBACK_URL='http://example.com'
```