### PR TITLE
Read Piwik configuration from correct globals

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -21,6 +21,8 @@
     "VERSION"               : false,
     "GIT_VERSION"           : false,
     "GIT_COMMIT_HASH"       : false,
+    "PIWIK_URL"             : false,
+    "PIWIK_ID"              : false,
     "SENTRY_REPORT_DIALOG"  : false,
     "SENTRY_DSN"            : false,
     "FEEDBACK_URL"          : false,

--- a/src/main.js
+++ b/src/main.js
@@ -10,8 +10,8 @@ import AppContainer from './containers/AppContainer';
 
 // Piwik Configuration
 const piwik = PiwikReactRouter({
-  url: process.env.PIWIK_URL,
-  siteId: process.env.PIWIK_ID
+  url: PIWIK_URL,
+  siteId: PIWIK_ID
 });
 
 // Sentry config


### PR DESCRIPTION
Code tried to read from Piwik (nee. Matomo) config from process.env, when it should be read from the globals.