### PR TITLE
Show classification version in UI

### DIFF
--- a/src/components/Classification/ViewClassification/ViewClassification.js
+++ b/src/components/Classification/ViewClassification/ViewClassification.js
@@ -118,6 +118,10 @@ export class ViewClassification extends React.Component {
         'Lisätiedot',
         classification.additional_information
       );
+      const version = this.renderClassificationData(
+        'Versio',
+        classification.version
+      );
       return (
         <div className='col-xs-12 single-classification-container'>
           <ClassificationHeader
@@ -136,6 +140,7 @@ export class ViewClassification extends React.Component {
                   {descriptionInternal}
                   {relatedClassification}
                   {additionalInformation}
+                  {version}
                 </div>
               </div>
               {classification.function

--- a/src/components/Tos/Header/ClassificationHeader.js
+++ b/src/components/Tos/Header/ClassificationHeader.js
@@ -29,30 +29,37 @@ const ClassificationHeader = ({
       </div>
       {isOpen &&
         !!classification && (
-        <div className='row'>
-          <div className='col-xs-12'>
-            <div className='list-group-item col-xs-6'>
-              <strong>Kuvaus</strong>
-              <div>{classification.description || '\u00A0'}</div>
-            </div>
-            <div className='list-group-item col-xs-6'>
-              <strong>Sisäinen kuvaus</strong>
-              <div>{classification.description_internal || '\u00A0'}</div>
+        <div>
+          <div className='row'>
+            <div className='col-xs-12'>
+              <div className='list-group-item col-xs-6'>
+                <strong>Kuvaus</strong>
+                <div>{classification.description || '\u00A0'}</div>
+              </div>
+              <div className='list-group-item col-xs-6'>
+                <strong>Sisäinen kuvaus</strong>
+                <div>{classification.description_internal || '\u00A0'}</div>
+              </div>
             </div>
           </div>
-        </div>
-      )}
-      {isOpen &&
-        !!classification && (
-        <div className='row'>
-          <div className='col-xs-12'>
-            <div className='list-group-item col-xs-6'>
-              <strong>Liittyvä tehtäväluokka</strong>
-              <div>{classification.related_classification || '\u00A0'}</div>
+          <div className='row'>
+            <div className='col-xs-12'>
+              <div className='list-group-item col-xs-6'>
+                <strong>Liittyvä tehtäväluokka</strong>
+                <div>{classification.related_classification || '\u00A0'}</div>
+              </div>
+              <div className='list-group-item col-xs-6'>
+                <strong>Lisätiedot</strong>
+                <div>{classification.additional_information || '\u00A0'}</div>
+              </div>
             </div>
-            <div className='list-group-item col-xs-6'>
-              <strong>Lisätiedot</strong>
-              <div>{classification.additional_information || '\u00A0'}</div>
+          </div>
+          <div className='row'>
+            <div className='col-xs-12'>
+              <div className='list-group-item col-xs-6'>
+                <strong>Versio</strong>
+                <div>{classification.version || '\u00A0'}</div>
+              </div>
             </div>
           </div>
         </div>

--- a/src/components/Tos/Header/TosHeader.js
+++ b/src/components/Tos/Header/TosHeader.js
@@ -2,7 +2,6 @@ import React, { PropTypes } from 'react';
 import { Link } from 'react-router';
 
 import ActionButtons from './ActionButtons';
-import VersionSelector from '../VersionSelector/VersionSelector';
 
 const TosHeader = ({
   cancelEdit,
@@ -29,17 +28,14 @@ const TosHeader = ({
     <div className='single-tos-header'>
       <div className='row'>
         <div className='col-md-6 col-xs-12'>
-          <h3>
-            {tosName}{' '}
-            <Link to={`/view-classification/${classificationId}`} title='Avaa luokituksen tiedot'>
-              <i className='fa fa-info-circle'/>
-            </Link>
-          </h3>
-          <VersionSelector
-            tosId={tosId}
-            currentVersion={currentVersion}
-            versions={versions}
-          />
+          <span className='classification-header-text'>
+            <h3>
+              {tosName}{' '}
+              <Link to={`/view-classification/${classificationId}`} title='Avaa luokituksen tiedot'>
+                <i className='fa fa-info-circle'/>
+              </Link>
+            </h3>
+          </span>
         </div>
         <div className='document-buttons col-xs-12 col-md-6'>
           <ActionButtons

--- a/src/components/Tos/VersionSelector/VersionSelector.js
+++ b/src/components/Tos/VersionSelector/VersionSelector.js
@@ -22,7 +22,7 @@ const VersionSelector = ({ tosId, currentVersion, versions, router }) => {
 
   return (
     <div>
-      <label className='helerm-version-label' htmlFor={name}>Versio:</label>
+      <label className='helerm-version-label' htmlFor={name}>Käsittelyprosessin versio:</label>
       <Select
         id={name}
         name={name}

--- a/src/components/Tos/ViewTos/ViewTos.js
+++ b/src/components/Tos/ViewTos/ViewTos.js
@@ -17,6 +17,7 @@ import TosHeader from 'components/Tos/Header/TosHeader';
 import ClassificationHeader from 'components/Tos/Header/ClassificationHeader';
 import ValidationBarContainer from 'components/Tos/ValidationBar/ValidationBarContainer';
 import VersionData from 'components/Tos/Version/VersionData';
+import VersionSelector from '../VersionSelector/VersionSelector';
 
 import Popup from 'components/Popup';
 
@@ -692,6 +693,11 @@ export class ViewTOS extends React.Component {
                       classification={classification}
                       isOpen={selectedTOS.is_classification_open}
                       setVisibility={setClassificationVisibility}
+                    />
+                    <VersionSelector
+                      tosId={selectedTOS.id}
+                      currentVersion={selectedTOS.version}
+                      versions={selectedTOS.version_history}
                     />
                     <VersionData
                       attributeTypes={attributeTypes}

--- a/src/components/Tos/ViewTos/ViewTos.scss
+++ b/src/components/Tos/ViewTos/ViewTos.scss
@@ -159,3 +159,9 @@
     margin-right: 15px;
   }
 }
+
+.classification-header-text {
+  display: flex;
+  min-height: 96px;
+  align-items: center;
+}


### PR DESCRIPTION
 - display classification version in tos and classification views
 - move tos version dropdown menu below classification info
 - rename tos dropdown label from "versio" to "käsittelyprosessin
   versio"

this fixes #414 