### PR TITLE
TIED-70: Docker build fails

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,22 +11,25 @@ COPY ./yarn.lock .
 COPY ./src ./src
 COPY ./server ./server
 COPY ./public ./public
+COPY ./.eslintrc.json .
+COPY ./.prettierrc .
 
 # Official image has npm log verbosity as info. More info - https://github.com/nodejs/docker-node#verbosity
 ENV NPM_CONFIG_LOGLEVEL warn
 
 EXPOSE ${PORT}
 # Yarn
-ENV YARN_VERSION 1.19.1
+ENV YARN_VERSION 1.22.19
 RUN yarn policies set-version $YARN_VERSION
 RUN bash /tools/apt-install.sh build-essential
 
 # Install npm dependencies and build the bundle
 ENV PATH /app/node_modules/.bin:$PATH
 RUN yarn config set network-timeout 300000
+RUN yarn cache clean --force
 RUN yarn
 RUN chgrp 0 .yarn && chmod g+w .yarn
-RUN yarn cache clean --force && yarn build
+RUN yarn build
 # Allow minimal writes to get the frontend server running
 
 RUN bash /tools/apt-cleanup.sh build-essential


### PR DESCRIPTION
Implements fix for docker build failing, reason was that after sonarcloud fixes eslintrc.json file was not copied to docker and that caused issues with the build.