### PR TITLE
TIED-79 Fix: Dockerfile should not copy .env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ USER default
 RUN yarn cache clean --force
 RUN yarn
 
-COPY .eslintrc.json .eslintignore .prettierrc .env /app/
+COPY .eslintrc.json .eslintignore .prettierrc /app/
 COPY ./src /app/src
 COPY ./public /app/public
 


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->

Bug fix: Dockerfile should not copy .env

## Related Issue(s)

**[TIED-79](https://helsinkisolutionoffice.atlassian.net/browse/TIED-79)**

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Tested running both development and production on local machine.

## Additional Notes

## Screenshots / Videos


[TIED-79]: https://helsinkisolutionoffice.atlassian.net/browse/TIED-79?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ