### PR TITLE
TIED-117 hotfix: move babel plugins to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "author": "City of Helsinki",
   "license": "MIT",
   "dependencies": {
+    "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
     "@fortawesome/fontawesome-free": "^6.3.0",
     "@sentry/browser": "^7.73.0",
     "@sentry/react": "^7.37.2",
@@ -98,8 +99,5 @@
   "resolutions": {
     "postcss-custom-properties": "^13.1.3",
     "react-refresh": "^0.11.0"
-  },
-  "devDependencies": {
-    "@babel/plugin-proposal-private-property-in-object": "^7.21.11"
   }
 }


### PR DESCRIPTION
# Hotfix: move babel plugins to dependencies

## Description

<!-- Describe your changes in detail -->
Hotfix: move @babel/plugin-proposal-private-property-in-object to dependencies

## Related Issue(s)

**[TIED-117](https://helsinkisolutionoffice.atlassian.net/browse/TIED-117)**

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

## Additional Notes

## Screenshots / Videos


[TIED-117]: https://helsinkisolutionoffice.atlassian.net/browse/TIED-117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ