### PR TITLE
Tied 134 fix edit new document

### DIFF
--- a/src/components/Tos/Phase/Phase.jsx
+++ b/src/components/Tos/Phase/Phase.jsx
@@ -609,7 +609,7 @@ class Phase extends React.Component {
                   type='action'
                   submit={this.addAction}
                   typeOptions={this.generateTypeOptions(this.props.actionTypes)}
-                  defaultAttributes={generateDefaultAttributes(this.props.attributeTypes, 'action')}
+                  defaultAttributes={generateDefaultAttributes(this.props.attributeTypes, 'action', this.state.showMore)}
                   newDefaultAttributes={this.state.actionDefaultAttributes}
                   newTypeSpecifier={this.state.actionTypeSpecifier}
                   newType={this.state.actionType}

--- a/src/components/Tos/ViewTos/ViewTos.jsx
+++ b/src/components/Tos/ViewTos/ViewTos.jsx
@@ -747,7 +747,7 @@ class ViewTOS extends React.Component {
                           type='phase'
                           submit={this.createNewPhase}
                           typeOptions={this.generateTypeOptions(this.props.phaseTypes)}
-                          defaultAttributes={generateDefaultAttributes(attributeTypes, 'phase')}
+                          defaultAttributes={generateDefaultAttributes(attributeTypes, 'phase', this.state.showMore)}
                           newDefaultAttributes={this.state.phaseDefaultAttributes}
                           newTypeSpecifier={this.state.phaseTypeSpecifier}
                           newType={this.state.phaseType}

--- a/src/utils/attributeHelper.js
+++ b/src/utils/attributeHelper.js
@@ -62,13 +62,13 @@ export const getDisplayLabelForAttribute = ({
   return attributeValue;
 };
 
-export const generateDefaultAttributes = (attributeTypes, type) => {
+export const generateDefaultAttributes = (attributeTypes, type, showMore) => {
   const attributes = {};
   Object.keys(attributeTypes).forEach((key) => {
     if (
       Object.hasOwn(attributeTypes, key) &&
-      ((this.state.showMore && attributeTypes[key].allowedIn.indexOf(type) >= 0 && key !== 'PhaseType') ||
-        (!this.state.showMore && attributeTypes[key].defaultIn.indexOf(type) >= 0)) &&
+      ((showMore && attributeTypes[key].allowedIn.indexOf(type) >= 0 && key !== 'PhaseType') ||
+        (!showMore && attributeTypes[key].defaultIn.indexOf(type) >= 0)) &&
       key !== 'TypeSpecifier'
     ) {
       if (attributeTypes[key].requiredIf.length) {

--- a/src/utils/helpers.jsx
+++ b/src/utils/helpers.jsx
@@ -397,5 +397,5 @@ export const randomActionId = () => {
   const array = new Uint32Array(1);
   const random = crypto.getRandomValues(array);
 
-  return random.toString(36).replace(/[^a-z]+/g, '');
+  return random.toString(36).replace(/[^a-zA-Z0-9]+/g, '');
 };


### PR DESCRIPTION
## Description

First commit fixes `randomActionId()` which has an weird regexp. It removed all non lower case alphabets from random string, so it ended up as empty string in this case. Empty string as an id was the main problem of the original bug (Editing new document didn't work)

I'm not sure what was original intent of the regexp, maybe it tried to remove special chars from the string, but equation was wrong. I fixed it to remove all non alphanumerics from random string...so in the end, returned random id is just alphanumeric and will work in all use cases this function is used.


Second commit fixes broken "new Phase" action. There was a `this.` in a `generateDefaultAttributes()` -function without context for `this.`. I moved `this.` call to correct place

## Related Issue(s)

**[TIED-134](https://helsinkisolutionoffice.atlassian.net/browse/TIED-134)**

## Motivation and Context

- Editing new document didn't work
- Creating new phase "Uusi toimenpide" didn't work

## How Has This Been Tested?

- created new document in UI and close it. Then then edit it and press "ok" (now it works, before UI stucked here)
- create new phase "Uusi toimenpide" in UI (now it don't crash)

There is a video in Jira ticket

## Additional Notes

## Screenshots / Videos

<img width="769" alt="Screenshot 2024-02-01 at 17 32 59" src="https://github.com/City-of-Helsinki/helerm-ui/assets/507917/736fef8b-c6ac-4133-8ac7-48adb90b35d8">

<img width="276" alt="Screenshot 2024-02-01 at 17 33 29" src="https://github.com/City-of-Helsinki/helerm-ui/assets/507917/b50ec87b-ec0c-4483-9ed1-dc6f6878b118">


[TIED-134]: https://helsinkisolutionoffice.atlassian.net/browse/TIED-134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ