### PR TITLE
fix: no pre inspection errors -bug TIED-142

### DIFF
--- a/src/components/Tos/ValidationBar/__tests__/ValidationBar.test.jsx
+++ b/src/components/Tos/ValidationBar/__tests__/ValidationBar.test.jsx
@@ -100,8 +100,12 @@ describe('<Navigation />', () => {
     const history = createBrowserHistory();
 
     renderComponent(history);
-
+    // find error group
     expect(screen.getByRole('heading', { name: 'Käsittelyprosessi' })).toBeInTheDocument();
+    // find correct errors
+    expect(screen.getByText('Julkisuusluokka')).toBeInTheDocument();
+    expect(screen.getByText('Säilytysajan laskentaperuste')).toBeInTheDocument();
+    expect(screen.getByText('Rekisteröinti/ Tietojärjestelmä')).toBeInTheDocument();
   });
 
   it('should not render errors for valid TOS', () => {

--- a/src/components/Tos/ValidationBar/__tests__/__snapshots__/ValidationBar.test.jsx.snap
+++ b/src/components/Tos/ValidationBar/__tests__/__snapshots__/ValidationBar.test.jsx.snap
@@ -91,44 +91,8 @@ exports[`<Navigation /> > should render correctly 1`] = `
             Rekisteröinti/ Tietojärjestelmä
           </div>
         </div>
-        <div>
-          <div
-            class="sidebar-content-phase"
-          >
-            <div
-              class="parent-name"
-            >
-              Vireillepano/-tulo
-            </div>
-            <div
-              class="missing-attributes"
-            >
-              <div
-                class="warn-attribute"
-              >
-                <i
-                  class="fa-solid fa-circle-exclamation"
-                />
-                 
-                Rekisteröinti/ Tietojärjestelmä
-              </div>
-            </div>
-          </div>
-        </div>
-        <div>
-          <div
-            class="sidebar-content-phase"
-          >
-            <div
-              class="parent-name"
-            >
-              Vireillepano/-tulo
-            </div>
-            <div
-              class="missing-attributes"
-            />
-          </div>
-        </div>
+        <div />
+        <div />
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Description

Pre inspection didn't show errors on `action` or `record` -level. 

Logic of `ValidationBar.jsx:generateInvalidAttributes()` -function was complex and got some errors. It renders 3 level tree (`phase`-`action`-`record`), but `action` and `record` levels referenced incorrectly root level data and didn't render errors. I fixed the logic and made it little bit easier.

## Related Issue(s)

**[TIED-142](https://helsinkisolutionoffice.atlassian.net/browse/TIED-142)**

## How Has This Been Tested?

How to test instructions in Jira ticket

[PR test environment](https://tiedonohjaus-pr527-ui.dev.hel.ninja/)



[TIED-142]: https://helsinkisolutionoffice.atlassian.net/browse/TIED-142?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ