### PR TITLE
Disable Dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,5 @@ updates:
       interval: "daily"
     commit-message:
       prefix: "deps"
+    # Disable version updates and only allow security updates
+    open-pull-requests-limit: 0


### PR DESCRIPTION
## Description

Disabled Dependabot [version updates](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates), because it seems they will flood us with open PRs. This doesn't affect [security updates](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates).

## Related Issue(s)

**[RAT-201](https://helsinkisolutionoffice.atlassian.net/browse/RAT-201)**

[RAT-201]: https://helsinkisolutionoffice.atlassian.net/browse/RAT-201?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ