### PR TITLE
fix: navigation filter classification by state TIED-204

### DIFF
--- a/src/components/InfinityMenu/InfinityMenu.jsx
+++ b/src/components/InfinityMenu/InfinityMenu.jsx
@@ -13,6 +13,7 @@ import Sticky from 'react-sticky-el';
 import ClassificationLink from './ClassificationLink';
 import EmptyTree from './EmptyTree';
 import Exporter from '../Exporter';
+import Loader from '../Loader';
 import SearchInputs from './SearchInput/SearchInputs';
 import SearchFilters from './SearchFilter/SearchFilters';
 
@@ -467,12 +468,16 @@ const InfinityMenu = ({
       if (displayTree.length) {
         return displayTree;
       }
-      if (emptyTreeComponent && !isFetching) {
+      // Only show loader during initialization when Header loader is not active
+      if (!isFetching && isInitializing) {
+        return <Loader show />;
+      }
+      if (emptyTreeComponent) {
         return React.createElement(emptyTreeComponent, emptyTreeComponentProps);
       }
       return null;
     },
-    [emptyTreeComponent, emptyTreeComponentProps, isFetching],
+    [emptyTreeComponent, emptyTreeComponentProps, isFetching, isInitializing],
   );
 
   useEffect(() => {
@@ -591,6 +596,7 @@ const InfinityMenu = ({
                       setSearchInput={setSearchInput}
                       removeSearchInput={removeSearchInput}
                       onFilterConditionChange={onFilterConditionChange}
+                      disabled={isFetching || isInitializing}
                     />
                     <div
                       className={classnames({
@@ -604,6 +610,7 @@ const InfinityMenu = ({
                         isUser={isUser}
                         filters={filters}
                         handleFilterChange={handleFilterChange}
+                        disabled={isFetching || isInitializing}
                       />
                     </div>
                   </div>

--- a/src/components/InfinityMenu/SearchFilter/SearchFilter.jsx
+++ b/src/components/InfinityMenu/SearchFilter/SearchFilter.jsx
@@ -12,6 +12,7 @@ const SearchFilter = ({
   multi = true,
   className = 'col-sm-6',
   isVisible = true,
+  isDisabled = false,
 }) => {
   if (!isVisible) {
     return null;
@@ -28,6 +29,7 @@ const SearchFilter = ({
         isMulti={multi}
         options={options}
         isClearable
+        isDisabled={isDisabled}
         onChange={(emittedValue) => handleChange(resolveReturnValues(emittedValue, multi))}
       />
     </div>
@@ -37,6 +39,7 @@ const SearchFilter = ({
 SearchFilter.propTypes = {
   className: PropTypes.string,
   handleChange: PropTypes.func,
+  isDisabled: PropTypes.bool,
   isVisible: PropTypes.bool,
   multi: PropTypes.bool,
   options: PropTypes.array,

--- a/src/components/InfinityMenu/SearchFilter/SearchFilters.jsx
+++ b/src/components/InfinityMenu/SearchFilter/SearchFilters.jsx
@@ -5,7 +5,7 @@ import classNames from 'classnames';
 import SearchFilter from './SearchFilter';
 import { statusFilters } from '../../../constants';
 
-const SearchFilters = ({ attributeTypes, isDetailSearch, isUser, filters, handleFilterChange }) => {
+const SearchFilters = ({ attributeTypes, isDetailSearch, isUser, filters, handleFilterChange, disabled = false }) => {
   const statusFilterOptions = statusFilters;
   const retentionPeriods = attributeTypes?.RetentionPeriod ? attributeTypes?.RetentionPeriod.values : [];
 
@@ -25,6 +25,7 @@ const SearchFilters = ({ attributeTypes, isDetailSearch, isUser, filters, handle
         value={filters.statusFilters.values}
         options={statusFilterOptions}
         handleChange={(values) => handleFilterChange(values, 'statusFilters')}
+        isDisabled={disabled}
       />
       <SearchFilter
         placeholder='Suodata säilytysajan mukaan'
@@ -32,6 +33,7 @@ const SearchFilters = ({ attributeTypes, isDetailSearch, isUser, filters, handle
         options={retentionPeriodOptions}
         handleChange={(values) => handleFilterChange(values, 'retentionPeriodFilters')}
         isVisible={isDetailSearch}
+        isDisabled={disabled}
       />
     </div>
   );
@@ -39,6 +41,7 @@ const SearchFilters = ({ attributeTypes, isDetailSearch, isUser, filters, handle
 
 SearchFilters.propTypes = {
   attributeTypes: PropTypes.object,
+  disabled: PropTypes.bool,
   isDetailSearch: PropTypes.bool,
   isUser: PropTypes.bool.isRequired,
   filters: PropTypes.object.isRequired,

--- a/src/components/InfinityMenu/SearchInput/SearchInputs.jsx
+++ b/src/components/InfinityMenu/SearchInput/SearchInputs.jsx
@@ -19,6 +19,7 @@ const SearchInputs = ({
   setSearchInput,
   removeSearchInput,
   onFilterConditionChange,
+  disabled = false,
 }) =>
   searchInputs.map((input, index) => (
     <div
@@ -33,6 +34,7 @@ const SearchInputs = ({
         searchInput={input}
         placeholder='Etsi...'
         setSearchInput={(event) => setSearchInput(index, event.target.value)}
+        disabled={disabled}
       />
       {isDetailSearch && (
         <div className='filters-detail-search-input-buttons'>
@@ -40,7 +42,7 @@ const SearchInputs = ({
             <Select
               className='Select'
               autoBlur
-              isDisabled={index > 0}
+              isDisabled={disabled || index > 0}
               placeholder='Ehto'
               value={FILTER_CONDITION_OPTIONS.find(({ value }) => value === filterCondition)}
               isClearable={false}
@@ -54,6 +56,7 @@ const SearchInputs = ({
             onClick={() => removeSearchInput(index)}
             title='Poista hakuehto'
             aria-label='Poista hakuehto'
+            disabled={disabled}
           >
             <span className='fa-solid fa-minus' aria-hidden='true' />
           </button>
@@ -64,6 +67,7 @@ const SearchInputs = ({
               onClick={addSearchInput}
               title='Lisää hakuehto'
               aria-label='Lisää hakuehto'
+              disabled={disabled}
             >
               <span className='fa-solid fa-plus' aria-hidden='true' />
             </button>
@@ -82,6 +86,7 @@ SearchInputs.propTypes = {
   setSearchInput: PropTypes.func.isRequired,
   removeSearchInput: PropTypes.func.isRequired,
   onFilterConditionChange: PropTypes.func.isRequired,
+  disabled: PropTypes.bool,
 };
 
 export default SearchInputs;

--- a/src/components/Navigation/__tests__/Navigation.test.jsx
+++ b/src/components/Navigation/__tests__/Navigation.test.jsx
@@ -8,6 +8,10 @@ import renderWithProviders, { storeDefaultState } from '../../../utils/renderWit
 import Navigation from '../Navigation';
 import api from '../../../utils/api';
 import { classification } from '../../../utils/__mocks__/mockHelpers';
+import useAuth from '../../../hooks/useAuth';
+
+vi.mock('../../../hooks/useAuth');
+const mockUseAuth = vi.mocked(useAuth);
 
 const middlewares = [thunk];
 const mockStore = configureStore(middlewares);
@@ -42,7 +46,16 @@ const renderComponent = (storeOverride) => {
   );
 };
 
+const findPendingAction = (actionsList) =>
+  actionsList.find((action) => action.type === 'navigation/fetchNavigation/pending');
+
 describe('<Navigation />', () => {
+  beforeAll(() => {
+    mockUseAuth.mockReturnValue({
+      getApiToken: vi.fn().mockReturnValue(undefined),
+      authenticated: false,
+    });
+  });
   it('renders correctly', async () => {
     renderComponent();
   });
@@ -57,7 +70,12 @@ describe('<Navigation />', () => {
         {
           type: 'navigation/fetchNavigation/pending',
           payload: undefined,
-          meta: expect.anything(),
+          meta: expect.objectContaining({
+            arg: expect.objectContaining({
+              includeRelated: false,
+              token: undefined,
+            }),
+          }),
         },
         {
           type: 'navigation/receiveNavigation',
@@ -78,9 +96,60 @@ describe('<Navigation />', () => {
           payload: {
             ...mockClassificationResponse,
           },
-          meta: expect.anything(),
+          meta: expect.objectContaining({
+            arg: expect.objectContaining({
+              includeRelated: false,
+              token: undefined,
+            }),
+          }),
         },
       ]),
     );
+  });
+
+  describe('authenticated user filtering', () => {
+    beforeEach(() => {
+      mockUseAuth.mockReturnValue({
+        getApiToken: vi.fn().mockReturnValue('test-token'),
+        authenticated: true,
+      });
+    });
+
+    afterEach(() => {
+      mockUseAuth.mockReturnValue({
+        getApiToken: vi.fn().mockReturnValue(undefined),
+        authenticated: false,
+      });
+    });
+
+    it('renders navigation with state filter dropdown for authenticated user', async () => {
+      const store = mockStore(storeDefaultState);
+
+      const { container } = renderComponent(store);
+
+      await waitFor(() => {
+        expect(container.querySelector('.navigation-container')).toBeInTheDocument();
+
+        expect(container.innerHTML).toContain('Suodata tilan mukaan...');
+      });
+
+      await waitFor(() => {
+        expect(container.querySelector('input[placeholder="Etsi..."]')).toBeInTheDocument();
+        expect(container.querySelector('.Select')).toBeInTheDocument();
+      });
+    });
+
+    it('fetches navigation with token when authenticated', async () => {
+      const store = mockStore(storeDefaultState);
+
+      renderComponent(store);
+
+      await waitFor(() => {
+        const actions = store.getActions();
+        const pendingAction = findPendingAction(actions);
+        expect(pendingAction).toBeDefined();
+        expect(pendingAction.meta.arg.token).toBe('test-token');
+      });
+    });
   });
 });

--- a/src/store/reducers/__tests__/navigation.test.js
+++ b/src/store/reducers/__tests__/navigation.test.js
@@ -1,35 +1,449 @@
-/* eslint-disable no-underscore-dangle */
-import { cloneDeep } from 'lodash';
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
 
-import navigationReducer, { initialState } from '../navigation';
+import navigationReducer, {
+  initialState,
+  fetchNavigationThunk,
+  parseNavigationSliceAction,
+  setNavigationVisibility,
+  navigationErrorSliceAction,
+  receiveNavigationSliceAction,
+  getTOS,
+  getTOSPath,
+  itemsSelector,
+  isFetchingSelector,
+  includeRelatedSelector,
+  isOpenSelector,
+  navigationListSelector,
+  timestampSelector,
+  navigationItemsSelector,
+} from '../navigation';
+import api from '../../../utils/api';
+import { classification } from '../../../utils/__mocks__/mockHelpers';
+import * as helpers from '../../../utils/helpers';
 
-describe('(Redux Module) Navigation', () => {
-  describe('(Reducer) NavigationReducer', () => {
-    let _initialState;
-    beforeEach(() => {
-      _initialState = cloneDeep(initialState);
+const middlewares = [thunk];
+const mockStore = configureMockStore(middlewares);
+
+vi.mock('../../../utils/helpers', () => ({
+  convertToTree: vi.fn(),
+  itemById: vi.fn(),
+}));
+
+const mockClassificationResponse = {
+  count: classification.length,
+  next: null,
+  previous: null,
+  results: classification,
+};
+
+const mockClassificationResponseWithNext = {
+  count: classification.length,
+  next: 'http://api.example.com/classification/?page=2',
+  previous: null,
+  results: classification.slice(0, 3),
+};
+
+const mockClassificationResponsePage2 = {
+  count: classification.length,
+  next: null,
+  previous: 'http://api.example.com/classification/?page=1',
+  results: classification.slice(3),
+};
+
+const createMockState = (overrides = {}) => ({
+  ...initialState,
+  ...overrides,
+});
+
+const testReducerAction = (action, state = initialState) => navigationReducer(state, action);
+
+const setupApiMock = (method, response) => {
+  return () => vi.spyOn(api, method).mockResolvedValueOnce({ ok: true, json: () => response });
+};
+
+const setupApiMockError = (method, error) => {
+  return () => vi.spyOn(api, method).mockRejectedValueOnce(error);
+};
+
+const testAsyncThunk = async (thunk, mockSetup, storeState = {}) => {
+  mockSetup();
+  const store = mockStore(storeState);
+  await store.dispatch(thunk);
+  return store.getActions();
+};
+
+const hasActionType = (actions, actionType) => actions.some((action) => action.type === actionType);
+
+const hasReceiveNavigation = (actions) => hasActionType(actions, 'navigation/receiveNavigation');
+const hasParseNavigation = (actions) => hasActionType(actions, 'navigation/parseNavigation');
+const hasNavigationError = (actions) => hasActionType(actions, 'navigation/navigationError');
+const findRejectedAction = (actions) => actions.find((action) => action.type === 'navigation/fetchNavigation/rejected');
+const filterReceiveActions = (actions) => actions.filter((action) => action.type === 'navigation/receiveNavigation');
+
+const expectAsyncActions = (actions, baseType, status = 'fulfilled') => {
+  expect(hasActionType(actions, `${baseType}/pending`)).toBe(true);
+  expect(hasActionType(actions, `${baseType}/${status}`)).toBe(true);
+};
+
+const createJsonResponse = (data) => () => data;
+
+describe('Navigation Reducer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Helper Functions', () => {
+    describe('getTOS', () => {
+      it('should get TOS from selectedTOS.classification', () => {
+        const mockTOS = { id: 'tos-1', name: 'Test TOS' };
+        const selectedTOS = { classification: { id: 'class-1' } };
+        const items = [];
+        const classification = { id: 'class-2' };
+
+        helpers.itemById.mockReturnValue(mockTOS);
+
+        const result = getTOS(selectedTOS, items, classification);
+
+        expect(helpers.itemById).toHaveBeenCalledWith(items, 'class-1');
+        expect(result).toBe(mockTOS);
+      });
+
+      it('should get TOS from classification when selectedTOS.classification is not available', () => {
+        const mockTOS = { id: 'tos-1', name: 'Test TOS' };
+        const selectedTOS = {};
+        const items = [];
+        const classification = { id: 'class-1' };
+
+        helpers.itemById.mockReturnValue(mockTOS);
+
+        const result = getTOS(selectedTOS, items, classification);
+
+        expect(helpers.itemById).toHaveBeenCalledWith(items, 'class-1');
+        expect(result).toBe(mockTOS);
+      });
+
+      it('should return null when no classification is available', () => {
+        const selectedTOS = {};
+        const items = [];
+        const classification = {};
+
+        const result = getTOS(selectedTOS, items, classification);
+
+        expect(result).toBeNull();
+      });
     });
-    it('Should be a function.', () => {
+
+    describe('getTOSPath', () => {
+      it('should return tosPath when available', () => {
+        const tos = { tosPath: ['path', 'to', 'tos'], path: ['other', 'path'] };
+        const result = getTOSPath(tos);
+        expect(result).toEqual(['path', 'to', 'tos']);
+      });
+
+      it('should return path when tosPath is not available', () => {
+        const tos = { path: ['path', 'to', 'tos'] };
+        const result = getTOSPath(tos);
+        expect(result).toEqual(['path', 'to', 'tos']);
+      });
+
+      it('should return empty array when neither tosPath nor path is available', () => {
+        const tos = {};
+        const result = getTOSPath(tos);
+        expect(result).toEqual([]);
+      });
+
+      it('should return empty array when tos is null', () => {
+        const result = getTOSPath(null);
+        expect(result).toEqual([]);
+      });
+    });
+  });
+
+  describe('Reducer', () => {
+    it('should be a function', () => {
       expect(navigationReducer).toBeInstanceOf(Function);
     });
 
-    it('Should initialize with a correct state', () => {
-      expect(navigationReducer(undefined, {})).toEqual(_initialState);
+    it('should initialize with correct state', () => {
+      expect(navigationReducer(undefined, {})).toEqual(initialState);
     });
 
-    it('Should return the previous state if an action was not matched.', () => {
+    it('should return previous state for unknown actions', () => {
       let state = navigationReducer(undefined, {});
-      expect(state).toEqual(_initialState);
-      state = navigationReducer(state, {
-        type: 'DOESNOTACTUALLYEXISTLOL',
-      });
-      expect(state).toEqual(_initialState);
+      expect(state).toEqual(initialState);
+
+      state = navigationReducer(state, { type: 'UNKNOWN_ACTION' });
+      expect(state).toEqual(initialState);
+
       state = navigationReducer(state, { type: 'navigation/fetchNavigation/pending', meta: { arg: {} } });
-      expect(state.isFetching).toEqual(true);
-      state = navigationReducer(state, {
-        type: 'DOESNOTACTUALLYEXISTLOL',
+      expect(state.isFetching).toBe(true);
+
+      state = navigationReducer(state, { type: 'UNKNOWN_ACTION' });
+      expect(state.isFetching).toBe(true);
+    });
+
+    describe('Action Reducers', () => {
+      it('should parse navigation and set items', () => {
+        const mockItems = [{ id: '1', name: 'Item 1' }];
+        const result = testReducerAction(parseNavigationSliceAction({ items: mockItems }));
+
+        expect(result.isFetching).toBe(false);
+        expect(result.items).toEqual(mockItems);
+        expect(result.timestamp).toEqual(expect.any(String));
       });
-      expect(state.isFetching).toEqual(true);
+
+      it('should set navigation visibility', () => {
+        const result = testReducerAction(setNavigationVisibility(false));
+        expect(result.is_open).toBe(false);
+      });
+
+      it('should handle navigation error', () => {
+        const state = createMockState({
+          list: [{ id: '1' }],
+          isFetching: true,
+          items: [{ id: '1' }],
+        });
+
+        const result = testReducerAction(navigationErrorSliceAction(), state);
+
+        expect(result.list).toEqual([]);
+        expect(result.isFetching).toBe(false);
+        expect(result.items).toEqual([]);
+        expect(result.timestamp).toEqual(expect.any(String));
+      });
+
+      it('should receive navigation data for first page', () => {
+        const mockItems = [{ id: '1', name: 'Item 1' }];
+        const result = testReducerAction(
+          receiveNavigationSliceAction({
+            items: mockItems,
+            includeRelated: true,
+            page: 1,
+          }),
+        );
+
+        expect(result.includeRelated).toBe(true);
+        expect(result.list).toEqual(mockItems);
+        expect(result.page).toBe(1);
+      });
+
+      it('should append navigation data for subsequent pages', () => {
+        const initialItems = [{ id: '1', name: 'Item 1' }];
+        const newItems = [{ id: '2', name: 'Item 2' }];
+        const state = createMockState({ list: initialItems });
+
+        const result = testReducerAction(
+          receiveNavigationSliceAction({
+            items: newItems,
+            includeRelated: true,
+            page: 2,
+          }),
+          state,
+        );
+
+        expect(result.list).toEqual([...initialItems, ...newItems]);
+        expect(result.page).toBe(2);
+      });
+    });
+  });
+
+  describe('Async Thunks', () => {
+    describe('fetchNavigationThunk', () => {
+      it('should fetch navigation successfully', async () => {
+        helpers.convertToTree.mockReturnValue([]);
+        const actions = await testAsyncThunk(
+          fetchNavigationThunk({ includeRelated: false, page: 1 }),
+          setupApiMock('get', mockClassificationResponse),
+          { navigation: { includeRelated: false, isFetching: false, list: [] } },
+        );
+
+        expectAsyncActions(actions, 'navigation/fetchNavigation');
+        expect(hasReceiveNavigation(actions)).toBe(true);
+        expect(hasParseNavigation(actions)).toBe(true);
+      });
+
+      it('should fetch navigation with token when provided', async () => {
+        helpers.convertToTree.mockReturnValue([]);
+        const mockApiGet = vi.spyOn(api, 'get').mockResolvedValueOnce({
+          ok: true,
+          json: createJsonResponse(mockClassificationResponse),
+        });
+
+        const store = mockStore({ navigation: { includeRelated: false, isFetching: false, list: [] } });
+        await store.dispatch(fetchNavigationThunk({ includeRelated: false, page: 1, token: 'test-token' }));
+
+        expect(mockApiGet).toHaveBeenCalledWith(
+          'classification',
+          {
+            include_related: false,
+            page_size: expect.any(Number),
+            page: 1,
+          },
+          {},
+          'test-token',
+        );
+      });
+
+      it('should handle pagination correctly', async () => {
+        helpers.convertToTree.mockReturnValue([]);
+        vi.spyOn(api, 'get')
+          .mockResolvedValueOnce({
+            ok: true,
+            json: createJsonResponse(mockClassificationResponseWithNext),
+          })
+          .mockResolvedValueOnce({
+            ok: true,
+            json: createJsonResponse(mockClassificationResponsePage2),
+          });
+
+        const store = mockStore({ navigation: { includeRelated: false, isFetching: false, list: [] } });
+        await store.dispatch(fetchNavigationThunk({ includeRelated: false, page: 1 }));
+
+        const actions = store.getActions();
+
+        const receiveActions = filterReceiveActions(actions);
+        expect(receiveActions.length).toBe(2);
+        expect(receiveActions[0].payload.page).toBe(1);
+        expect(receiveActions[1].payload.page).toBe(2);
+      });
+
+      it('should prevent concurrent fetches when appropriate', async () => {
+        const store = mockStore({
+          navigation: {
+            includeRelated: true,
+            isFetching: true,
+            list: [],
+          },
+        });
+
+        const result = await store.dispatch(fetchNavigationThunk({ includeRelated: false, page: 1 }));
+
+        expect(result.payload).toBeNull();
+      });
+
+      it('should handle fetch navigation error', async () => {
+        const actions = await testAsyncThunk(
+          fetchNavigationThunk({ includeRelated: false, page: 1 }),
+          setupApiMockError('get', new Error('Network error')),
+          { navigation: { includeRelated: false, isFetching: false, list: [] } },
+        );
+
+        expectAsyncActions(actions, 'navigation/fetchNavigation', 'rejected');
+        expect(hasNavigationError(actions)).toBe(true);
+      });
+
+      it('should handle non-Error exceptions', async () => {
+        const actions = await testAsyncThunk(
+          fetchNavigationThunk({ includeRelated: false, page: 1 }),
+          setupApiMockError('get', 'String error'),
+          { navigation: { includeRelated: false, isFetching: false, list: [] } },
+        );
+
+        expectAsyncActions(actions, 'navigation/fetchNavigation', 'rejected');
+        const rejectedAction = findRejectedAction(actions);
+        expect(rejectedAction.payload).toBe('Failed to fetch navigation');
+      });
+    });
+  });
+
+  describe('Extra Reducers', () => {
+    describe('fetchNavigationThunk lifecycle', () => {
+      it('should handle pending state', () => {
+        const action = {
+          type: fetchNavigationThunk.pending.type,
+          meta: { arg: { includeRelated: true } },
+        };
+
+        const result = testReducerAction(action);
+
+        expect(result.isFetching).toBe(true);
+        expect(result.includeRelated).toBe(true);
+      });
+
+      it('should handle fulfilled state', () => {
+        const state = createMockState({ isFetching: true });
+        const action = { type: fetchNavigationThunk.fulfilled.type };
+
+        const result = testReducerAction(action, state);
+
+        expect(result.isFetching).toBe(false);
+      });
+
+      it('should handle rejected state', () => {
+        const state = createMockState({
+          isFetching: true,
+          list: [{ id: '1' }],
+          items: [{ id: '1' }],
+        });
+        const action = { type: fetchNavigationThunk.rejected.type };
+
+        const result = testReducerAction(action, state);
+
+        expect(result.isFetching).toBe(false);
+        expect(result.list).toEqual([]);
+        expect(result.items).toEqual([]);
+        expect(result.timestamp).toEqual(expect.any(String));
+      });
+    });
+  });
+
+  describe('Selectors', () => {
+    const mockState = {
+      navigation: createMockState({
+        items: [{ id: '1', name: 'Item 1' }],
+        isFetching: true,
+        includeRelated: true,
+        is_open: false,
+        list: [{ id: '1' }, { id: '2' }],
+        timestamp: '12345',
+      }),
+    };
+
+    it('should select items', () => {
+      expect(itemsSelector(mockState)).toEqual(mockState.navigation.items);
+    });
+
+    it('should select isFetching', () => {
+      expect(isFetchingSelector(mockState)).toBe(true);
+    });
+
+    it('should select includeRelated', () => {
+      expect(includeRelatedSelector(mockState)).toBe(true);
+    });
+
+    it('should select is_open', () => {
+      expect(isOpenSelector(mockState)).toBe(false);
+    });
+
+    it('should select list', () => {
+      expect(navigationListSelector(mockState)).toEqual(mockState.navigation.list);
+    });
+
+    it('should select timestamp', () => {
+      expect(timestampSelector(mockState)).toBe('12345');
+    });
+
+    describe('navigationItemsSelector', () => {
+      it('should return items when includeRelated is true', () => {
+        const state = {
+          navigation: createMockState({
+            includeRelated: true,
+            items: [{ id: '1' }],
+          }),
+        };
+        expect(navigationItemsSelector(state)).toEqual([{ id: '1' }]);
+      });
+
+      it('should return empty array when includeRelated is false', () => {
+        const state = {
+          navigation: createMockState({
+            includeRelated: false,
+            items: [{ id: '1' }],
+          }),
+        };
+        expect(navigationItemsSelector(state)).toEqual([]);
+      });
     });
   });
 });

--- a/src/store/reducers/navigation.js
+++ b/src/store/reducers/navigation.js
@@ -38,7 +38,7 @@ export const initialState = {
 
 export const fetchNavigationThunk = createAsyncThunk(
   'navigation/fetchNavigation',
-  async ({ includeRelated = false, page = 1 }, { dispatch, getState, rejectWithValue }) => {
+  async ({ includeRelated = false, page = 1, token = null }, { dispatch, getState, rejectWithValue }) => {
     try {
       const pageSize = includeRelated ? config.SEARCH_PAGE_SIZE : config.RESULTS_PER_PAGE;
 
@@ -55,11 +55,16 @@ export const fetchNavigationThunk = createAsyncThunk(
         return null;
       }
 
-      const response = await api.get('classification', {
-        include_related: includeRelated,
-        page_size: pageSize,
-        page,
-      });
+      const response = await api.get(
+        'classification',
+        {
+          include_related: includeRelated,
+          page_size: pageSize,
+          page,
+        },
+        {},
+        token,
+      );
 
       const json = await response.json();
 
@@ -72,7 +77,7 @@ export const fetchNavigationThunk = createAsyncThunk(
       );
 
       if (json.next) {
-        await dispatch(fetchNavigationThunk({ includeRelated, page: page + 1 }));
+        await dispatch(fetchNavigationThunk({ includeRelated, page: page + 1, token }));
       } else {
         const list = getState().navigation.list || [];
         const orderedTree = convertToTree(list);

--- a/src/utils/__mocks__/api/classification.json
+++ b/src/utils/__mocks__/api/classification.json
@@ -129,5 +129,128 @@
     "function_version": 3,
     "function_valid_from": "2018-01-01",
     "function_valid_to": "2019-01-31"
+  },
+  {
+    "id": "test-classification-draft-001",
+    "created_at": "2023-01-01T00:00:00.000000Z",
+    "modified_at": "2023-01-01T10:30:00.000000Z",
+    "modified_by": "Draft User",
+    "version": 1,
+    "state": "draft",
+    "valid_from": null,
+    "valid_to": null,
+    "code": "08 01 00 00",
+    "title": "Luonnos tehtäväluokka",
+    "parent": null,
+    "description": "Test draft classification",
+    "description_internal": "Internal draft description",
+    "related_classification": "",
+    "additional_information": "",
+    "function_allowed": true,
+    "version_history": [
+      {
+        "state": "draft",
+        "version": 1,
+        "modified_at": "2023-01-01T10:30:00.000000Z",
+        "valid_from": null,
+        "valid_to": null,
+        "modified_by": "Draft User"
+      }
+    ],
+    "function": "test-function-draft-001",
+    "function_state": "draft",
+    "function_attributes": {
+      "PersonalData": "Ei sisällä henkilötietoja",
+      "PublicityClass": "Julkinen",
+      "RetentionPeriod": "3",
+      "RetentionReason": "Test draft retention reason",
+      "InformationSystem": "Test Draft System",
+      "SocialSecurityNumber": "Ei sisällä henkilötunnusta"
+    },
+    "function_version": 1,
+    "function_valid_from": "2023-01-01",
+    "function_valid_to": null
+  },
+  {
+    "id": "test-classification-sent-for-review-001",
+    "created_at": "2023-01-02T00:00:00.000000Z",
+    "modified_at": "2023-01-02T14:15:00.000000Z",
+    "modified_by": "Review User",
+    "version": 1,
+    "state": "sent_for_review",
+    "valid_from": null,
+    "valid_to": null,
+    "code": "09 01 00 00",
+    "title": "Tarkastuksessa oleva tehtäväluokka",
+    "parent": null,
+    "description": "Test classification sent for review",
+    "description_internal": "Internal review description",
+    "related_classification": "",
+    "additional_information": "",
+    "function_allowed": true,
+    "version_history": [
+      {
+        "state": "draft",
+        "version": 1,
+        "modified_at": "2023-01-02T10:00:00.000000Z",
+        "valid_from": null,
+        "valid_to": null,
+        "modified_by": "Review User"
+      }
+    ],
+    "function": "test-function-review-001",
+    "function_state": "sent_for_review",
+    "function_attributes": {
+      "PersonalData": "Sisältää henkilötietoja",
+      "PublicityClass": "Osittain salassa pidettävä",
+      "RetentionPeriod": "7",
+      "RetentionReason": "Test review retention reason",
+      "InformationSystem": "Test Review System",
+      "SocialSecurityNumber": "Ei sisällä henkilötunnusta"
+    },
+    "function_version": 1,
+    "function_valid_from": "2023-01-02",
+    "function_valid_to": null
+  },
+  {
+    "id": "test-classification-waiting-approval-001",
+    "created_at": "2023-01-03T00:00:00.000000Z",
+    "modified_at": "2023-01-03T16:45:00.000000Z",
+    "modified_by": "Approval User",
+    "version": 1,
+    "state": "waiting_for_approval",
+    "valid_from": null,
+    "valid_to": null,
+    "code": "10 01 00 00",
+    "title": "Hyväksyntää odottava tehtäväluokka",
+    "parent": null,
+    "description": "Test classification waiting for approval",
+    "description_internal": "Internal approval description",
+    "related_classification": "",
+    "additional_information": "",
+    "function_allowed": true,
+    "version_history": [
+      {
+        "state": "draft",
+        "version": 1,
+        "modified_at": "2023-01-03T10:00:00.000000Z",
+        "valid_from": null,
+        "valid_to": null,
+        "modified_by": "Approval User"
+      }
+    ],
+    "function": "test-function-waiting-001",
+    "function_state": "waiting_for_approval",
+    "function_attributes": {
+      "PersonalData": "Sisältää henkilötietoja",
+      "PublicityClass": "Julkinen",
+      "RetentionPeriod": "10",
+      "RetentionReason": "Test waiting approval retention reason",
+      "InformationSystem": "Test Approval System",
+      "SocialSecurityNumber": "Sisältää henkilötunnuksen"
+    },
+    "function_version": 1,
+    "function_valid_from": "2023-01-03",
+    "function_valid_to": null
   }
 ]


### PR DESCRIPTION
## Description
Filtering navigation by classification state was broken due to React 18 migration. Fixing the functionality and adding some tests.

<!-- Describe your changes in detail -->

## Related Issue(s)

**[TIED-204](https://helsinkisolutionoffice.atlassian.net/browse/TIED-204)**

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

## Additional Notes

## Screenshots / Videos


[TIED-204]: https://helsinkisolutionoffice.atlassian.net/browse/TIED-204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ