### PR TITLE
feat: implement multi-value handling for SecurityReason

### DIFF
--- a/src/store/reducers/ui.js
+++ b/src/store/reducers/ui.js
@@ -74,6 +74,15 @@ const processTypeList = (types, list) => {
   });
 };
 
+const forceMultiValueFields = (identifier, multiIn) => {
+  if (identifier !== 'SecurityReason') {
+    return multiIn;
+  }
+
+  const forcedTypes = ['function', 'record'];
+  return [...new Set([...multiIn, ...forcedTypes])];
+};
+
 const processAttributeTypes = (attributes, validationRules) => {
   const attributeTypeList = {};
 
@@ -100,6 +109,7 @@ const processAttributeTypes = (attributes, validationRules) => {
         .filter((key) =>
           find(validationRules[key].properties[result.identifier]?.anyOf, (item) => item.type === 'array'),
         );
+      const normalizedMultiIn = forceMultiValueFields(result.identifier, multiIn);
 
       const requiredIn = Object.keys(validationRules)
         .filter((key) => validationRules[key]?.required)
@@ -151,7 +161,7 @@ const processAttributeTypes = (attributes, validationRules) => {
         values: result.values,
         allowedIn,
         defaultIn,
-        multiIn,
+        multiIn: normalizedMultiIn,
         requiredIf,
         requiredIn,
         required,

--- a/src/utils/__mocks__/api/attributeRules.json
+++ b/src/utils/__mocks__/api/attributeRules.json
@@ -779,7 +779,10 @@
       "record",
       "function"
     ],
-    "multiIn": [],
+    "multiIn": [
+      "record",
+      "function"
+    ],
     "requiredIf": [
       {
         "key": "PublicityClass",

--- a/src/utils/__tests__/validateTos.test.js
+++ b/src/utils/__tests__/validateTos.test.js
@@ -104,6 +104,82 @@ describe('(TOS validation)', () => {
       });
     });
 
+    describe('Multiple allowed values in SecurityReason', () => {
+      const errors = validateTOS(
+        {
+          ...validTOS,
+          attributes: {
+            ...validTOS.attributes,
+            PublicityClass: 'Salassa pidettävä',
+            RetentionPeriod: '10',
+            RetentionPeriodStart: 'Asian lopullinen ratkaisu',
+            SecurityPeriod: '25',
+            'Restriction.SecurityPeriodStart': 'Asian ratkaisu',
+            SecurityReason: ['JulkL 24.1 § 1 kohta', 'JulkL 24.1 § 2 kohta'],
+          },
+        },
+        attributeRules,
+      );
+
+      shouldReturnArray(errors);
+
+      it('Should not have errors', () => {
+        expect(errors.length).toEqual(0);
+      });
+    });
+
+    describe('Single allowed value in SecurityReason', () => {
+      const errors = validateTOS(
+        {
+          ...validTOS,
+          attributes: {
+            ...validTOS.attributes,
+            PublicityClass: 'Salassa pidettävä',
+            RetentionPeriod: '10',
+            RetentionPeriodStart: 'Asian lopullinen ratkaisu',
+            SecurityPeriod: '25',
+            'Restriction.SecurityPeriodStart': 'Asian ratkaisu',
+            SecurityReason: 'JulkL 24.1 § 1 kohta',
+          },
+        },
+        attributeRules,
+      );
+
+      shouldReturnArray(errors);
+
+      it('Should not have errors', () => {
+        expect(errors.length).toEqual(0);
+      });
+    });
+
+    describe('Empty SecurityReason array when conditionally required', () => {
+      const errors = validateTOS(
+        {
+          ...validTOS,
+          attributes: {
+            ...validTOS.attributes,
+            PublicityClass: 'Salassa pidettävä',
+            RetentionPeriod: '10',
+            RetentionPeriodStart: 'Asian lopullinen ratkaisu',
+            SecurityPeriod: '25',
+            'Restriction.SecurityPeriodStart': 'Asian ratkaisu',
+            SecurityReason: [],
+          },
+        },
+        attributeRules,
+      );
+
+      shouldReturnArray(errors);
+
+      it(SHOULD_HAVE_ONE_ERROR_STRING, () => {
+        expect(errors.length).toEqual(1);
+      });
+
+      it('The error should be SecurityReason', () => {
+        expect(errors[0]).toEqual('SecurityReason');
+      });
+    });
+
     describe('"All or none" - RetentionPeriod of -1 shouldn\'t have RetentionPeriodStart', () => {
       const errors = validateTOS(
         {

--- a/src/utils/helpers.jsx
+++ b/src/utils/helpers.jsx
@@ -317,8 +317,9 @@ export const resolveSelectValues = (options, receivedValue, multi = false) => {
   if (!receivedValue) {
     return null;
   }
-  if (multi && Array.isArray(receivedValue)) {
-    return options.filter(({ value }) => receivedValue.includes(value));
+  if (multi) {
+    const values = Array.isArray(receivedValue) ? receivedValue : [receivedValue];
+    return options.filter(({ value }) => values.includes(value));
   }
   return options.find(({ value }) => value === receivedValue);
 };

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -1,5 +1,13 @@
 import { difference, includes, uniq } from 'lodash';
 
+const hasAttributeValue = (value) => {
+  if (Array.isArray(value)) {
+    return value.length > 0;
+  }
+
+  return value !== undefined && value !== null && value !== '';
+};
+
 /**
  * Validate conditional rules
  * @param key
@@ -7,8 +15,12 @@ import { difference, includes, uniq } from 'lodash';
  * @param attributes
  * @returns {Boolean}
  */
-export const validateConditionalRules = (key, attributeTypes, attributes) => {
+export const validateConditionalRules = (key, attributeTypes, attributes = {}) => {
   const { requiredIf } = attributeTypes[key];
+
+  if (!attributes) {
+    return false;
+  }
 
   let valid = false;
 
@@ -16,7 +28,12 @@ export const validateConditionalRules = (key, attributeTypes, attributes) => {
     // for each attribute
     requiredIf.forEach((item) => {
       // for each item in requiredIf and if requiredIf has attribute
-      if (item.key === attribute && includes(item.values, attributes[attribute]?.value)) {
+      const attributeValue = attributes[attribute]?.value;
+      const matchesRequiredIf = Array.isArray(attributeValue)
+        ? attributeValue.some((value) => includes(item.values, value))
+        : includes(item.values, attributeValue);
+
+      if (item.key === attribute && matchesRequiredIf) {
         // if requiredIf has same value as attribute
         valid = true;
       }
@@ -36,19 +53,27 @@ export const validateConditionalRules = (key, attributeTypes, attributes) => {
 const createValidateErrors = (type) => (obj, rules) => {
   const keys = Object.keys(rules).filter((key) => Object.hasOwn(rules, key));
 
+  const matchesAllowedValues = (rule, value) => {
+    if (!rule.values.length) {
+      return true;
+    }
+
+    if (!hasAttributeValue(value)) {
+      return false;
+    }
+
+    return isValueValidOption(value, rule.values);
+  };
+
   const errors = keys.filter((key) => {
     const rule = rules[key];
 
     const isRequired = rules[key].required;
     const isRequiredInType = includes(rule.requiredIn, type);
-    const objHasRuleAttribute = Boolean(obj.attributes[key]);
+    const objHasRuleAttribute = hasAttributeValue(obj.attributes[key]);
 
     const isAttributeAllowedInType = includes(rules[key].allowedIn, type);
-    const isValid =
-      includes(
-        rule.values.map(({ value }) => value),
-        obj.attributes[key],
-      ) || rule.values.length === 0;
+    const isValid = matchesAllowedValues(rule, obj.attributes[key]);
     const allowValuesOutsideChoices = includes(rule.allowValuesOutsideChoicesIn, type);
 
     return (
@@ -58,19 +83,31 @@ const createValidateErrors = (type) => (obj, rules) => {
     );
   });
 
+  const isPredicateRequired = (predicateValue, values) => {
+    const hasPredicate = Array.isArray(predicateValue) ? predicateValue.length > 0 : typeof predicateValue === 'string';
+
+    if (!hasPredicate) {
+      return false;
+    }
+
+    if (Array.isArray(predicateValue)) {
+      return predicateValue.some((value) => includes(values, value));
+    }
+
+    return includes(values, predicateValue);
+  };
+
   const conditionallyRequired = keys
     .filter((key) => rules[key].requiredIf.length > 0)
     .map((key) => ({ key, items: rules[key].requiredIf }))
     .filter(({ key, items }) =>
       items.some((item) => {
         const predicateValue = obj.attributes[item.key];
-        const hasPredicate = typeof predicateValue === 'string';
+        const requiredByPredicate = isPredicateRequired(predicateValue, item.values);
 
-        const isPredicateRequired = hasPredicate && includes(item.values, predicateValue);
+        const objHasRuleAttribute = hasAttributeValue(obj.attributes[key]);
 
-        const objHasRuleAttribute = !!obj.attributes[key];
-
-        return (isPredicateRequired && !objHasRuleAttribute) || (!isPredicateRequired && objHasRuleAttribute);
+        return (requiredByPredicate && !objHasRuleAttribute) || (!requiredByPredicate && objHasRuleAttribute);
       }),
     )
     .map(({ key }) => key);


### PR DESCRIPTION
## Description

Adds multi-select support for `SecurityReason` so multiple reasons can be selected at the same time.

## Related Issue(s)

**[TIED-289](https://helsinkisolutionoffice.atlassian.net/browse/TIED-289)**

## Motivation and Context

`SecurityReason` needed to support selecting more than one value at once.

## How Has This Been Tested?

Tested locally in the UI and with existing automated tests. Not against real backend, yet.

## Additional Notes

For a single selected value the payload remains a string, and for multiple selected values it is sent as an array.

## Screenshots / Videos

\-


[TIED-289]: https://helsinkisolutionoffice.atlassian.net/browse/TIED-289?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ